### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish Extension
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nur-srijan/markdown-preview-export/security/code-scanning/1](https://github.com/nur-srijan/markdown-preview-export/security/code-scanning/1)

To fix the problem, add a `permissions:` block at the root level of the workflow. This block should restrict repository token access to only what is necessary. The minimal starting point recommended by GitHub is `contents: read`, which grants read-only access to repository contents, preventing any unintended write actions by the workflow. You should insert this block directly beneath the `name:` field (best practice), before the `on:` block. No other code changes are necessary, and no additional permissions seem required for this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
