### PR TITLE
🧪 add edge case test for getHtmlForWebview with empty input

### DIFF
--- a/src/test/suite/helpers.test.ts
+++ b/src/test/suite/helpers.test.ts
@@ -52,6 +52,12 @@ suite('Helpers Test Suite', () => {
     });
 
     suite('getHtmlForWebview', () => {
+        test('should handle empty input correctly', () => {
+            const html = getHtmlForWebview('');
+            assert.ok(html.includes('<body'), 'Should contain body tag');
+            assert.ok(html.includes('</body>'), 'Should contain closing body tag');
+        });
+
         test('should convert basic Markdown to HTML', () => {
             const markdown = '# Hello\n\nThis is **bold** text.';
             const html = getHtmlForWebview(markdown);


### PR DESCRIPTION
The `getHtmlForWebview` function in `src/helpers.ts` was missing a test for the empty string edge case. I have added a new test case to `src/test/suite/helpers.test.ts` that verifies the function returns a valid HTML document (containing `<body>` and `</body>` tags) when called with an empty string. This improves test coverage for basic input handling.

Verification was performed via source analysis of the function's wrapping logic and a manual check of the modified test file. Standard test execution was attempted but limited by environment network issues.

---
*PR created automatically by Jules for task [1920832043564289684](https://jules.google.com/task/1920832043564289684) started by @nur-srijan*